### PR TITLE
D6 migration version

### DIFF
--- a/JAK_modifications.md
+++ b/JAK_modifications.md
@@ -1,0 +1,6 @@
+JAK Modifications to si_publications.controller.inc
+=====================================================
+
+~ lines 62-63 and 201-202: Changed $url from http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm to http://staff.research.si.edu/srb_search_export_action.cfm.
+
+~ line 107: Changed format from 'full_html' to '2'.

--- a/JAK_modifications.md
+++ b/JAK_modifications.md
@@ -1,6 +1,0 @@
-JAK Modifications to si_publications.controller.inc
-=====================================================
-
-~ lines 62-63 and 201-202: Changed $url from http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm to http://staff.research.si.edu/srb_search_export_action.cfm.
-
-~ line 107: Changed format from 'full_html' to '2'.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,59 @@ SI publications
 This module was written by Anthony Braun at NZP. If you have any questions or want to help improve this module, please email me at brauna@si.edu
 
 ### SUMMARY
- The SI Publications module allows you to import publications for your unit's scientists from Smithsonian Libraries. This can be done manually or automatically as a cron task using the Drupal queue API.
+ The SI Publications module allows you to import publications for your unit's scientists from Smithsonian Libraries.
+	This can be done manually or automatically as a cron task using the Drupal queue API.
 
     
 ### REQUIREMENTS
- You must have created a "scientist" content type (it can be named anything you like). This content type MUST contain the following two fields:
- 1. A text field for the scientist's SI Profiles ID (available here: https://profiles.si.edu/). This field can be named anything, but it must be a text field.
- 2. A longtext field for recent papers. This must allow unlimited values and it must be HTML-enabled. Again, the field name does not matter.
+ You must have created a "scientist" content type (it can be named anything you like). This content type MUST contain the following two
+	fields:
+ 1. A text field for the scientist's SI Profiles ID (available here: https://profiles.si.edu/). This field can be named anything,
+	but it must be a text field.
+ 2. A longtext field for recent papers. This must allow unlimited values and it must be HTML-enabled. Again, the field name does not
+	matter.
+ 3. Each new content type comes with a default title field. You can choose to hide it or use it as you like.
+
+### OTHER PREPARATION
+ For each scientist or scholar for whom you want to import publications data into your website, create a record or node of the "scientist"
+	content type (or whatever you called your new content type):
+ 1. If you use the title field, one way to use it is to fill in the name of the scientist.
+ 2. In order to get the scientist's SI Profiles ID, you need to search for the scientist at https://profiles.si.edu/search by name.
+	Once you find a scientist's profile, the SI Profiles ID will be part of the URL. For example, a search for Torsten Dikow will result
+	in a 	profile record at https://profiles.si.edu/display/nDikowT962012. The profile ID is DikowT962012.
+ 3. Leave your recent papers field blank. This field will be automatically populated when the import is done.
+
 
 ### INSTALLATION
  Install as usual, see http://drupal.org/documentation/install/modules-themes/modules-7 for further information
 
 ### CONFIGURATION
  Go to /admin/content/publications/settings and fill out the form.
+
+ 1. Your Scientist Content Type: Select your "scientist" content type from the list of all your content types.
+ 2. Your SI profile ID field: Select your "SI profile ID" field from the listing of fields for the scientist content type.
+ 3. Your Recent Papers field: Select your "Recent Papers" field from the listing of fields for the scientist content type.
+ 4. Check the "Import via cron" box in order to get an up-to-date import every time a cron job runs.
+ 5. Number of papers to store for each scientist: The default is three (3), the maximum is ten (10).
+ 6. Include Altmetric icons next to citations: Check this box if you want an Altmetric badge to appear next to each publication that has a
+	valid DOI.
+ 7. Once you save your publication import settings, you can go to the Publications Import tab at /admin/content/publications in order to
+	run a manual import the first time.
+ 8. For each scientist record/node you should now see the three to ten recent papers imported into it. At the bottom of the record/node
+	you should also see an "All Papers" link to an all papers node for that scientist.
+
+
+If you checked the "Import via cron" box on the Publications Settings form above, you should get updated imports every time a cron job
+runs. If you did not check this box, you will need to run updated imports manually from the Publications Import tab.
+
+### MODIFICATIONS MADE BY JIM KOCHERT, NMNH WEBSITE ADMINISTRATOR
+JAK Modifications to si_publications.controller.inc
+=====================================================
+
+~ lines 62-63 and 201-202: Changed $url from http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm to
+	http://staff.research.si.edu/srb_search_export_action.cfm. [This the preferred URL.]
+
+~ line 107: Changed format from 'full_html' to '2'. [This is because my test website was migrated from Drupal 6 to D7.
+	In D6 the full HTML format is coded as '2'. A D7 website that starts out as a D7 website codes the full HTML format as 'full_html'.]
+~ lines 158-163: Added code to have Altmetric badges added to each recent paper in each scientist node.
+~ lines 227-229: Edited lines of code to make sure Altmetric badges are not duplicated on All Papers page.

--- a/README.md
+++ b/README.md
@@ -58,5 +58,7 @@ JAK Modifications to si_publications.controller.inc
 
 ~ line 107: Changed format from 'full_html' to '2'. [This is because my test website was migrated from Drupal 6 to D7.
 	In D6 the full HTML format is coded as '2'. A D7 website that starts out as a D7 website codes the full HTML format as 'full_html'.]
+
 ~ lines 158-163: Added code to have Altmetric badges added to each recent paper in each scientist node.
+
 ~ lines 227-229: Edited lines of code to make sure Altmetric badges are not duplicated on All Papers page.

--- a/includes/si_publications.controller.inc
+++ b/includes/si_publications.controller.inc
@@ -59,7 +59,8 @@ function si_publications_fetch($node) {
   $author_id = $node->{$si_profile_field}['und'][0]['value'];
 
   //set up SIL API call
-  $url = 'http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm';
+  //$url = 'http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm';
+  $url = 'http://staff.research.si.edu/srb_search_export_action.cfm';
   $data = array(
     'search_term' =>  $author_id,
     // 'submit' => 'Export+data',
@@ -103,7 +104,7 @@ function si_publications_fetch($node) {
 
                 $node->{$recent_papers_field}[LANGUAGE_NONE][$n] = array(
                   'value' => t($formatted_pub),
-                  'format' => 'full_html',
+                  'format' => '2', //'full_html',
                   );
 
                 //a paper was changed so we will need to save the node
@@ -153,12 +154,13 @@ function si_publications_format($unformatted_pub) {
   $title      = $unformatted_pub['title'];
   //if a repository link exists, wrap the title in it
   $title      = isset($unformatted_pub['link']) ? ( '<a href="' . $unformatted_pub['link'] . '">' . $title . '</a>' ) : $title;
-  $doi        = isset($unformatted_pub['doi']) ?   (' <a href="' . $unformatted_pub['doi'] . '">' . $unformatted_pub['doi'] . '</a>' ) : null;
+  $doi        = isset($unformatted_pub['doi']) ?   (' <a href="' . $unformatted_pub['doi'] . '">' . $unformatted_pub['doi'] . '</a>' ) : null;  
   $pages      = isset($unformatted_pub['pages']) ? (', ' . $unformatted_pub['pages']) : null;
   $journal    = isset($unformatted_pub['journal']) ? ( '<em>' . $unformatted_pub['journal'] . '</em>' ) : null;
-
+  $altmetric_set = add_altmetric();
+  $altmetric  = ($altmetric_set && isset($unformatted_pub['doi'])) ? '<div id="show_metric" class="altmetric-embed altmetricIcon" data-badge-type="donut" data-badge-popover="left" data-hide-no-mentions="true" data-doi="' . $doi_stripped = str_replace('http://dx.doi.org/', '', $unformatted_pub['doi']) . '"></div>' : null;
   //put the paper reference in our format
-  $formatted_pub = $authors . ' ' . $date . '. ' . '<strong>' . $title . '</strong>. ' . $journal . $pages . '.' . $doi;
+  $formatted_pub = $altmetric . $authors . ' ' . $date . '. ' . '<strong>' . $title . '</strong>. ' . $journal . $pages . '.' . $doi;
   return $formatted_pub; 
 }
 
@@ -197,7 +199,8 @@ function si_publications_get_all_papers($node) {
 
   //grab the si profiles ID and get the papers from SIL
   $si_profiles_id = $node->{$si_profile_field}['und'][0]['value'];
-  $url = 'http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm?search_term=' . $si_profiles_id . '&submit=Export+data&date=&limit=authorID&format=JSON&Unit=All&count=2500';
+  // $url = 'http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm?search_term=' . $si_profiles_id . '&submit=Export+data&date=&limit=authorID&format=JSON&Unit=All&count=2500';
+  $url = 'http://staff.research.si.edu/srb_search_export_action.cfm?search_term=' . $si_profiles_id . '&submit=Export+data&date=&limit=authorID&format=JSON&Unit=All&count=2500';
 
   $result = drupal_http_request($url);
 
@@ -221,8 +224,9 @@ function si_publications_get_all_papers($node) {
       foreach($pub as $unformatted_pub) {
         //transform the array into a formatted string
         $formatted_pub = si_publications_format($unformatted_pub);
-        $altmetric  = ($altmetric_set && isset($unformatted_pub['doi'])) ? '<div id="show_metric" class="altmetric-embed altmetricIcon" data-badge-type="donut" data-badge-popover="left" data-hide-no-mentions="true" data-doi="' . $doi_stripped = str_replace('http://dx.doi.org/', '', $unformatted_pub['doi']) . '"></div>' : null;
-        $all_papers .= '<p class="paper-citation">' . $altmetric . $formatted_pub . '</p>';
+        // $altmetric  = ($altmetric_set && isset($unformatted_pub['doi'])) ? '<div id="show_metric" class="altmetric-embed altmetricIcon" data-badge-type="donut" data-badge-popover="left" data-hide-no-mentions="true" data-doi="' . $doi_stripped = str_replace('http://dx.doi.org/', '', $unformatted_pub['doi']) . '"></div>' : null;
+        // $all_papers .= '<p class="paper-citation">' . $altmetric . $formatted_pub . '</p>';
+		$all_papers .= '<p class="paper-citation">' . $formatted_pub . '</p>';
       }
     }
   }


### PR DESCRIPTION
JAK Modifications to si_publications.controller.inc
~ lines 62-63 and 201-202: Changed $url from http://prism.si.edu/sil/researchbib/srb_search_export_action.cfm to http://staff.research.si.edu/srb_search_export_action.cfm. [This the preferred URL.]

~ line 107: Changed format from 'full_html' to '2'. [This is because my test website was migrated from Drupal 6 to D7. In D6 the full HTML format is coded as '2'. A D7 website that starts out as a D7 website codes the full HTML format as 'full_html'.]

~ lines 158-163: Added code to have Altmetric badges added to each recent paper in each scientist node.

~ lines 227-229: Edited lines of code to make sure Altmetric badges are not duplicated on All Papers page.